### PR TITLE
Fix runtimepath commas

### DIFF
--- a/autoload/scriptmanager.vim
+++ b/autoload/scriptmanager.vim
@@ -188,6 +188,8 @@ fun! scriptmanager#Activate(...) abort
     " don't miss the after directories if they exist and
     " put them last! (Thanks to Oliver Teuliere)
     let rtp = split(&runtimepath,'\(\\\@<!\(\\.\)*\\\)\@<!,')
+    " Also need to pass them through the escaping function.
+    let s:new_runtime_paths = scriptmanager_util#EscapeRuntimePaths(s:new_runtime_paths)
     let &runtimepath=join(rtp[:0] + s:new_runtime_paths + rtp[1:]
                                   \ + filter(map(copy(s:new_runtime_paths),'v:val."/after"'), 'isdirectory(v:val)') ,",")
     unlet rtp

--- a/autoload/scriptmanager2.vim
+++ b/autoload/scriptmanager2.vim
@@ -422,7 +422,8 @@ fun! scriptmanager2#MergePluginFiles(plugins, skip_pattern)
     endif
   endfor
 
-  let runtimepaths = map(copy(a:plugins), 'substitute('','',''\\,'', scriptmanager#PluginRuntimePath(v:val),''g'')')
+  let runtimepaths = map(copy(a:plugins), 'scriptmanager#PluginRuntimePath(v:val)')
+  let runtimepaths = scriptmanager_util#EscapeRuntimePaths(runtimepaths)
 
   " 1)
   for r in runtimepaths

--- a/autoload/scriptmanager_util.vim
+++ b/autoload/scriptmanager_util.vim
@@ -257,6 +257,13 @@ fun! scriptmanager_util#RmFR(dir_or_file)
 endf
 
 
+" Prepare a list of runtimepaths as stored in the addon package data
+" for inclusion in &runtimepath.
+fun! scriptmanager_util#EscapeRuntimePaths(paths)
+  return map(copy(a:paths), 'substitute(v:val, '','', ''\\,'', ''g'')')
+endf
+
+
 " a "direct link" (found on the download page)
 " such as "http://downloads.sourceforge.net/project/gnuwin32/gzip/1.3.12-1/gzip-1.3.12-1-bin.zip"
 " can be downloaded this way:


### PR DESCRIPTION
Re: MarcWeber#17

This works for me, but I'm not using the MergePluginFiles stuff (unless it gets used by default now?), so conceivably there could be problems with that.  This commit moves the comma-escaping that gets applied to elements of `&runtimepath` into a function in scriptmanager_util.

It looks like the previous commit for this (dd3b36e8fdedddc235530a73c9b5bbaff6ec0b6c) would break the MergePluginFiles stuff due to having `substitute()` arguments in the wrong order.  I don't think it was affecting normal operation, since the changed code wasn't getting run.  That code should be fixed in this commit.

Doing `ActivateAddons SQLUti<TAB>` works with this patch.  With the parent tree, the runtimepath still has an unescaped comma in it.  I didn't really do any testing other than that.
