### PR TITLE
Check if a repo is available before asking for confirmation on Install() (2)

### DIFF
--- a/autoload/scriptmanager2.vim
+++ b/autoload/scriptmanager2.vim
@@ -40,6 +40,7 @@ endfun
 fun! scriptmanager2#Install(toBeInstalledList, ...)
   let toBeInstalledList = scriptmanager2#ReplaceAndFetchUrls(a:toBeInstalledList)
   let opts = a:0 == 0 ? {} : a:1
+  let auto_install = s:c['auto_install'] || get(opts,'auto_install',0)
   for name in toBeInstalledList
     if scriptmanager#IsPluginInstalled(name)
       continue
@@ -68,10 +69,11 @@ fun! scriptmanager2#Install(toBeInstalledList, ...)
     let pluginDir = scriptmanager#PluginDirByName(name)
     " ask user for to confirm installation unless he set auto_install
 
-    if confirm_install != 'y'
+    if auto_install || confirm_install != 'y'
       let confirm_install = input('Install plugin "'.name.'" into "'.s:c['plugin_root_dir'].'" ? [y/n]:','')
     endif
-    if s:c['auto_install'] || get(opts,'auto_install',0) || confirm_install == 'y'
+
+    if auto_install || confirm_install == 'y'
 
       let infoFile = scriptmanager#AddonInfoFile(name)
       call scriptmanager2#Checkout(pluginDir, repository)


### PR DESCRIPTION
I broke auto_install with the first commit, the second one fixes it. I just pasted the content of the previous pull request after this.

I'm not sure if this will accepted, but I thought I should bring it up anyway, since it was easy.

I expect to see errors from the installation process after the confirmation, except for the ones that can be checked with VAM's db like unavailable repos or deprecated plugins.

If the plugin is deprecated the user will be asked again for confirmation, I think that's not necessary.

Both issues are addressed by this commit.

I think some feedback should be given when skipping over an already installed plugin. Also, the error message for unknown repo is a bit cryptic, how a bout changing it? maybe to "No repository known for plugin ". Maybe add a reference to the documentation? I could add a commit for this, let me know.
