### PR TITLE
scriptmanager#Activate is being renamed to vam#ActivateAddons, but vim_script_manager (variable name) is not renamed to vim_addon_manager

### DIFF
--- a/autoload/scriptmanager.vim
+++ b/autoload/scriptmanager.vim
@@ -3,7 +3,7 @@ fun! s:UpdateVimrc()
   " for you. I'd like to ask the user. But not all are using shells so the
   " question can get lost.
   let cmd='%s@scriptmanager#Activate(@vam#ActivateAddons(@g | %s/\<vim_script_manager\>/vim_addon_manager/g'
-  let files = filter([$HOME."/.vimrc",$HOME.'/_vimrc'], 'filereadable(v:val)')
+  let files = filter([$HOME."/.vimrc",$HOME.'/_vimrc'], 'filewriteable(v:val)==1')
   if len(files) == 1
     echohl WarningMsg
     echomsg "scriptmanager#Activate and g:vim_script_manager were renamed to vam#ActivateAddons and g:vim_addon_manager."


### PR DESCRIPTION
scriptmanager#Activate is being renamed to vam#ActivateAddons, but vim_script_manager (variable name) is not renamed to vim_addon_manager.

By the way, who teached @Silex to modify user configuration files without any confirmation?
