### PR TITLE
Make ActivatedAddons throw no exception if it was called with an empty list of plugins to install

### DIFF
--- a/autoload/vam.vim
+++ b/autoload/vam.vim
@@ -301,7 +301,7 @@ fun! vam#ActivateAddons(...) abort
       endif
     endif
 
-    if empty(filter(copy(args[0]), 'get(s:c.activated_plugins, v:val, 0)'))
+    if empty(filter(copy(args[0]), 'get(s:c.activated_plugins, v:val, 0)')) && !empty(copy(args[0]))
       throw 'Not all plugins were activated'
     endif
   endif


### PR DESCRIPTION
This is the previous behavior. ZyX just added checking whether all requested plugins got installed, this is just an edge case that was overlooked.
