### PR TITLE
Fixed a bug when an event has more than one au groups

### DIFF
--- a/autoload/vam.vim
+++ b/autoload/vam.vim
@@ -340,7 +340,7 @@ fun! vam#ActivateAddons(...) abort
       for [group, events] in items(newaugs)
         for event in events
           if has_key(event_to_groups, event)
-            call add(event_to_groups, group)
+            call add(event_to_groups[event], group)
           else
             let event_to_groups[event] = [group]
           endif


### PR DESCRIPTION
event_to_group is a dict and not a list. Its values are lists.
