### PR TITLE
Check if p expansion is results in valid string

### DIFF
--- a/autoload/vam/utils.vim
+++ b/autoload/vam/utils.vim
@@ -55,7 +55,10 @@ fun! s:ShellDSL(special, cmd, ...) abort
       endfor
     endif
     if list[2] == 'p'
-      let p = expand(fnameescape(p))
+      let temp = expand(fnameescape(p))
+      if temp != ''
+        let p = temp
+      endif
     endif
     let r .= shellescape(p, a:special).x[len(list[0]):]
     unlet p


### PR DESCRIPTION
If the downloaded file is a zip file, the expand function of the zip file path sometimes gave a empty string.

This happened in vim version 7.3.

It happened on YankRing plugin for example.

This code, checks if the expanded path string is empty. If it is, it uses the non expanded string.
