### PR TITLE
overload vim-addons directory path

### DIFF
--- a/doc/vim-addon-manager-getting-started.txt
+++ b/doc/vim-addon-manager-getting-started.txt
@@ -170,7 +170,7 @@ commented version ~
           " VAM install location:
           let c = get(g:, 'vim_addon_manager', {})
           let g:vim_addon_manager = c
-          let c.plugin_root_dir = expand('$HOME/.vim/vim-addons', 1)
+          let c.plugin_root_dir = expand(get(c, 'plugin_root_dir', '$HOME/.vim/vim-addons'), 1)
           if !EnsureVamIsOnDisk(c.plugin_root_dir)
             echohl ErrorMsg | echomsg "No VAM found!" | echohl NONE
             return
@@ -212,7 +212,7 @@ minimal version ~
         fun! SetupVAM()
           let c = get(g:, 'vim_addon_manager', {})
           let g:vim_addon_manager = c
-          let c.plugin_root_dir = expand('$HOME', 1) . '/.vim/vim-addons'
+          let c.plugin_root_dir = expand(get(c, 'plugin_root_dir', '$HOME/.vim/vim-addons'), 1)
           let &rtp.=(empty(&rtp)?'':',').c.plugin_root_dir.'/vim-addon-manager'
           " let g:vim_addon_manager = { your config here see "commented version" example and help
           if !isdirectory(c.plugin_root_dir.'/vim-addon-manager/autoload')


### PR DESCRIPTION
allow to specify vim-addons directory in .vimrc instead of hardcoding it in the function itself; especially useful for users who tar-ball whole $HOME/.vim directory as their config without including all of the third-party add-ons that will checkout from repositories in new environment any way
